### PR TITLE
Fix the image name

### DIFF
--- a/docs/site/content/en/docs/how-to/engines/index.md
+++ b/docs/site/content/en/docs/how-to/engines/index.md
@@ -78,7 +78,7 @@ For **x86** processors use following images:
 
 For **ARM** processors use following images:
 - `devlikeapro/whatsapp-http-api:arm` - **Chromium**
-- `devlikeapro/whatsapp-http-api:arm-noweb`- **no browser installed**
+- `devlikeapro/whatsapp-http-api:noweb-arm`- **no browser installed**
 
 {{< alert icon="💡" text="Chrome version is not available in ARM" />}}
 


### PR DESCRIPTION
The image name is wrongly mentioned 
<img width="912" alt="image" src="https://github.com/devlikeapro/whatsapp-http-api/assets/2275957/2f59298f-3f16-405a-95d4-80652c7176ab">
