### PR TITLE
Fixpollmessages

### DIFF
--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -516,7 +516,7 @@ export abstract class WhatsappSession {
     chatId: string,
     request: ReadChatMessagesQuery,
   ): Promise<ReadChatMessagesResponse> {
-    const { query, filter } = MessagesForRead(chatId, request);
+    const { query, filter } = MessagesForRead(chatId, { ...request, includeSent: true });
     const messages = await this.getChatMessages(chatId, query, filter);
     this.logger.debug(`Found ${messages.length} messages to read`);
     if (messages.length === 0) {

--- a/src/core/utils/convertors.ts
+++ b/src/core/utils/convertors.ts
@@ -47,7 +47,7 @@ function daysToMs(days: number) {
 
 export function MessagesForRead(
   chatId: string,
-  request: ReadChatMessagesQuery,
+  request: ReadChatMessagesQuery & { includeSent?: boolean },
 ): {
   query: GetChatMessagesQuery;
   filter: GetChatMessagesFilter;
@@ -62,9 +62,11 @@ export function MessagesForRead(
   const after = Math.floor(afterMs / 1000);
   const filter: GetChatMessagesFilter = {
     'filter.ack': WAMessageAck.DEVICE,
-    'filter.fromMe': false,
     'filter.timestamp.gte': after,
   };
+  if (!request.includeSent) {
+    filter['filter.fromMe'] = false;
+  }
   return {
     query: query,
     filter: filter,


### PR DESCRIPTION
#### **Problem**
Poll messages (and other messages sent by the user) were not visible to the sender in their own chat history. This was caused by a hardcoded filter (`'filter.fromMe': false`) in the message fetching logic, which excluded all sent messages from being returned when displaying chat history. As a result, users could not see polls they themselves had sent, leading to confusion and a poor user experience.

#### **Solution**
We updated the message fetching logic to support an optional `includeSent` flag. When this flag is set to `true`, the filter that excludes sent messages is not applied, allowing both sent and received messages to be fetched and displayed.  
**Additionally, we updated the main chat reading implementation to always use `includeSent: true`, ensuring that all sent messages (including polls) are now visible to the sender by default.**  
This change is global for all chat reading operations, so users will always see their own sent poll messages and other sent messages in their chat history. The default behavior for other usages remains unchanged, ensuring backward compatibility.

Solves - #988