### PR TITLE
ChatWoot App security measure to avoid undesirable reboots in multi-tenant environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,12 @@ WHATSAPP_FILES_FOLDER=/app/.media
 # WAHA_APPS_JOBS_REMOVE_ON_FAIL_AGE=
 # WAHA_APPS_JOBS_REMOVE_ON_FAIL_COUNT
 
+# ChatWoot integration security
+# Restrict which session IDs can execute server commands (reboot, status) via ChatWoot
+# Supports exact matches and wildcard patterns (using * at the end)
+# Leave empty or unset to allow all sessions (default behavior)
+# CHATWOOT_PRIVILEGED_SESSIONS=session1,session2,admins_*
+
 
 # ==================================
 # ===== ADVANCED CONFIGURATION =====

--- a/.env.example
+++ b/.env.example
@@ -88,13 +88,6 @@ WHATSAPP_FILES_FOLDER=/app/.media
 # WAHA_APPS_JOBS_REMOVE_ON_FAIL_AGE=
 # WAHA_APPS_JOBS_REMOVE_ON_FAIL_COUNT
 
-# ChatWoot integration security
-# Restrict which session IDs can execute server commands (reboot, status) via ChatWoot
-# Supports exact matches and wildcard patterns (using * at the end)
-# Leave empty or unset to allow all sessions (default behavior)
-# CHATWOOT_PRIVILEGED_SESSIONS=session1,session2,admins_*
-
-
 # ==================================
 # ===== ADVANCED CONFIGURATION =====
 # ==================================

--- a/docs/CHATWOOT_SECURITY.md
+++ b/docs/CHATWOOT_SECURITY.md
@@ -1,0 +1,143 @@
+# ChatWoot Integration Security 
+
+## Overview
+
+By default, any session connected to ChatWoot can execute server commands like:
+- `server status` - Get server version and status information
+- `server reboot` - Gracefully reboot the server
+- `server reboot force` - Force reboot the server
+
+For security reasons, you may want to restrict these commands to only specific trusted sessions. This is especially the case when using the same instance for several customers and want to restrict sensitive commands to certain privileged sessions, or to avoid accidental server reboots that can disrupt the service level.
+
+## Configuration
+
+### Environment Variable
+
+Use the `CHATWOOT_PRIVILEGED_SESSIONS` environment variable to specify which session IDs are allowed to execute privileged commands. Supports both exact matches and wildcard patterns. ****Wildcard `*` will only be accepted at the end of the session ID.****
+
+```env
+# Allow specific sessions and wildcard patterns to execute server commands
+CHATWOOT_PRIVILEGED_SESSIONS=session1,session2,admins_*,monitoring_*
+
+# Or leave empty/unset to allow all sessions (default behavior)
+# CHATWOOT_PRIVILEGED_SESSIONS=
+```
+
+#### Pattern Matching
+
+- **Exact Match**: `session1` - matches only "session1"
+- **Wildcard Pattern**: `admins_*` - matches any session starting with "admins_" (e.g., "admins_john", "admins_mary", "admins_bot")
+- **Mixed**: `session1,admins_*,monitoring_*` - combines exact matches and patterns
+
+### Docker Compose
+
+Add the environment variable to your `docker-compose.yaml`:
+
+```yaml
+version: '3'
+services:
+  waha:
+    image: devlikeapro/waha:latest
+    environment:
+      - CHATWOOT_PRIVILEGED_SESSIONS=session1,session2
+    # ... other configuration
+```
+
+### Docker Run
+
+Pass the environment variable when running the container:
+
+```bash
+docker run -e CHATWOOT_PRIVILEGED_SESSIONS="session1,session2" devlikeapro/waha
+```
+
+## Behavior
+
+### When Restricted
+- Only sessions listed in `CHATWOOT_PRIVILEGED_SESSIONS` can execute `server status`, `server reboot`, and `server reboot force` commands
+- Unauthorized sessions receive the message: "❌ You are not authorized to execute this server command."
+- Access attempts are logged with a warning for security auditing
+
+### When Unrestricted (Default)
+- When `CHATWOOT_PRIVILEGED_SESSIONS` is empty or unset, all sessions can execute privileged commands
+- This maintains backward compatibility with existing installations, until needed.
+
+## Session Commands
+
+### Non-Privileged Commands (Always Available)
+These commands are available to all sessions regardless of the restriction:
+- `status` - Get session status
+- `restart` - Restart the session
+- `start` - Start the session
+- `stop` - Stop the session
+- `logout` - Logout from the session
+- `qr` - Get QR code for the session
+- `screenshot` - Get screenshot of the session
+- `help` - Show available commands
+
+### Privileged Commands (Restricted)
+These commands require session ID to be in `CHATWOOT_PRIVILEGED_SESSIONS`:
+- `server status` - Get server version and status
+- `server reboot` - Gracefully reboot the server
+- `server reboot force` - Force reboot the server
+
+## Example Scenarios
+
+### Development Environment
+```env
+# Allow all sessions (default)
+# CHATWOOT_PRIVILEGED_SESSIONS=
+```
+
+### Production Environment
+```env
+# Only allow admin and monitoring sessions
+CHATWOOT_PRIVILEGED_SESSIONS=admin-session,monitoring-bot
+```
+
+### Multi-tenant Setup
+```env
+# Only allow specific tenant admin sessions
+CHATWOOT_PRIVILEGED_SESSIONS=tenant1-admin,tenant2-admin,system-admin
+```
+
+### Wildcard Pattern Examples
+```env
+# Allow all admin sessions (admins_john, admins_mary, etc.)
+CHATWOOT_PRIVILEGED_SESSIONS=admins_*
+
+# Allow multiple patterns and specific sessions
+CHATWOOT_PRIVILEGED_SESSIONS=admins_*,monitoring_*,support_*,emergency-session
+
+# Department-based access
+CHATWOOT_PRIVILEGED_SESSIONS=ops_*,devops_*,sysadmin_*
+```
+
+#### Pattern Matching Examples
+| Pattern | Session ID | Match? | Explanation |
+|---------|------------|--------|-------------|
+| `admins_*` | `admins_john` | ✅ Yes | Starts with "admins_" |
+| `admins_*` | `admins_mary_team` | ✅ Yes | Starts with "admins_" |
+| `admins_*` | `admin_john` | ❌ No | Singular "admin" word |
+| `admins_*` | `john_admin` | ❌ No | Doesn't start with "admins_" |
+| `ops_*` | `ops_monitoring` | ✅ Yes | Starts with "ops_" |
+| `session1` | `session1` | ✅ Yes | Exact match |
+| `session1` | `session12` | ❌ No | Not exact match |
+
+## Troubleshooting
+
+### Command Rejected
+If you receive "❌ You are not authorized to execute this server command.":
+1. Check that your session ID is included in `CHATWOOT_PRIVILEGED_SESSIONS`
+2. Verify the session ID matches exactly (case-sensitive, no extra spaces)
+3. Restart the container after changing the environment variable
+
+### Logs
+Access denied attempts are logged as warnings:
+```
+WARN: Access denied: session mysession attempted privileged command server reboot
+```
+
+## Migration
+
+This feature is backward compatible. Existing installations will continue to work without any changes. To enable restrictions, simply add the `CHATWOOT_PRIVILEGED_SESSIONS` environment variable with your desired session IDs.

--- a/docs/CHATWOOT_SECURITY.md
+++ b/docs/CHATWOOT_SECURITY.md
@@ -7,60 +7,39 @@ By default, any session connected to ChatWoot can execute server commands like:
 - `server reboot` - Gracefully reboot the server
 - `server reboot force` - Force reboot the server
 
-For security reasons, you may want to restrict these commands to only specific trusted sessions. This is especially the case when using the same instance for several customers and want to restrict sensitive commands to certain privileged sessions, or to avoid accidental server reboots that can disrupt the service level.
+For security reasons, you may want to restrict these commands. This is especially important when using the same instance for multiple customers or to prevent accidental server reboots that can disrupt service.
 
 ## Configuration
 
-### Environment Variable
+### Per-App Configuration (Dashboard)
 
-Use the `CHATWOOT_PRIVILEGED_SESSIONS` environment variable to specify which session IDs are allowed to execute privileged commands. Supports both exact matches and wildcard patterns. ****Wildcard `*` will only be accepted at the end of the session ID.****
+Each ChatWoot app can be configured individually through the WAHA dashboard. This provides granular control and better security isolation.
 
-```env
-# Allow specific sessions and wildcard patterns to execute server commands
-CHATWOOT_PRIVILEGED_SESSIONS=session1,session2,admins_*,monitoring_*
+#### Dashboard Configuration
 
-# Or leave empty/unset to allow all sessions (default behavior)
-# CHATWOOT_PRIVILEGED_SESSIONS=
-```
+1. **Navigate to App Configuration**: Go to the WAHA dashboard and access "App Configuration"
+2. **Select ChatWoot App**: Choose the ChatWoot integration you want to configure
+3. **Toggle Server Commands**: Use the "Disable Server Commands" setting:
+   - `false` (default): Server commands are allowed
+   - `true`: Server commands are disabled for this app
 
-#### Pattern Matching
+#### Configuration Field
 
-- **Exact Match**: `session1` - matches only "session1"
-- **Wildcard Pattern**: `admins_*` - matches any session starting with "admins_" (e.g., "admins_john", "admins_mary", "admins_bot")
-- **Mixed**: `session1,admins_*,monitoring_*` - combines exact matches and patterns
-
-### Docker Compose
-
-Add the environment variable to your `docker-compose.yaml`:
-
-```yaml
-version: '3'
-services:
-  waha:
-    image: devlikeapro/waha:latest
-    environment:
-      - CHATWOOT_PRIVILEGED_SESSIONS=session1,session2
-    # ... other configuration
-```
-
-### Docker Run
-
-Pass the environment variable when running the container:
-
-```bash
-docker run -e CHATWOOT_PRIVILEGED_SESSIONS="session1,session2" devlikeapro/waha
+The ChatWoot app configuration includes:
+```typescript
+disableServerCommands: boolean = false  // Default: allow server commands
 ```
 
 ## Behavior
 
-### When Restricted
-- Only sessions listed in `CHATWOOT_PRIVILEGED_SESSIONS` can execute `server status`, `server reboot`, and `server reboot force` commands
-- Unauthorized sessions receive the message: "❌ You are not authorized to execute this server command."
-- Access attempts are logged with a warning for security auditing
+### When Server Commands are Enabled (Default)
+- All sessions can execute `server status`, `server reboot`, and `server reboot force` commands
+- This maintains backward compatibility with existing installations
 
-### When Unrestricted (Default)
-- When `CHATWOOT_PRIVILEGED_SESSIONS` is empty or unset, all sessions can execute privileged commands
-- This maintains backward compatibility with existing installations, until needed.
+### When Server Commands are Disabled
+- Attempts to execute server commands will be blocked
+- Users receive the message: "❌ Server commands are disabled for this ChatWoot integration."
+- Access attempts are logged with a warning for security auditing
 
 ## Session Commands
 
@@ -75,8 +54,8 @@ These commands are available to all sessions regardless of the restriction:
 - `screenshot` - Get screenshot of the session
 - `help` - Show available commands
 
-### Privileged Commands (Restricted)
-These commands require session ID to be in `CHATWOOT_PRIVILEGED_SESSIONS`:
+### Server Commands (Can be Restricted)
+These commands can be disabled per ChatWoot app:
 - `server status` - Get server version and status
 - `server reboot` - Gracefully reboot the server
 - `server reboot force` - Force reboot the server
@@ -84,60 +63,72 @@ These commands require session ID to be in `CHATWOOT_PRIVILEGED_SESSIONS`:
 ## Example Scenarios
 
 ### Development Environment
-```env
-# Allow all sessions (default)
-# CHATWOOT_PRIVILEGED_SESSIONS=
-```
+- **Setting**: `disableServerCommands: false`
+- **Result**: All server commands available for testing and development
 
-### Production Environment
-```env
-# Only allow admin and monitoring sessions
-CHATWOOT_PRIVILEGED_SESSIONS=admin-session,monitoring-bot
-```
+### Production Environment - Customer Facing
+- **Setting**: `disableServerCommands: true` 
+- **Result**: Customers cannot accidentally reboot the server
+
+### Production Environment - Admin Access
+- **Setting**: `disableServerCommands: false`
+- **Result**: Admin teams retain full server control
 
 ### Multi-tenant Setup
-```env
-# Only allow specific tenant admin sessions
-CHATWOOT_PRIVILEGED_SESSIONS=tenant1-admin,tenant2-admin,system-admin
+Create separate ChatWoot apps for different access levels:
+- **Customer Apps**: `disableServerCommands: true`
+- **Admin Apps**: `disableServerCommands: false`
+- **Monitoring Apps**: `disableServerCommands: false`
+
+## API Configuration
+
+You can also configure this programmatically when creating or updating ChatWoot apps:
+
+```json
+{
+  "url": "https://chatwoot.example.com",
+  "accountId": 12345,
+  "accountToken": "your-account-token",
+  "inboxId": 67890,
+  "inboxIdentifier": "your-inbox-token",
+  "locale": "en-US",
+  "disableServerCommands": true
+}
 ```
-
-### Wildcard Pattern Examples
-```env
-# Allow all admin sessions (admins_john, admins_mary, etc.)
-CHATWOOT_PRIVILEGED_SESSIONS=admins_*
-
-# Allow multiple patterns and specific sessions
-CHATWOOT_PRIVILEGED_SESSIONS=admins_*,monitoring_*,support_*,emergency-session
-
-# Department-based access
-CHATWOOT_PRIVILEGED_SESSIONS=ops_*,devops_*,sysadmin_*
-```
-
-#### Pattern Matching Examples
-| Pattern | Session ID | Match? | Explanation |
-|---------|------------|--------|-------------|
-| `admins_*` | `admins_john` | ✅ Yes | Starts with "admins_" |
-| `admins_*` | `admins_mary_team` | ✅ Yes | Starts with "admins_" |
-| `admins_*` | `admin_john` | ❌ No | Singular "admin" word |
-| `admins_*` | `john_admin` | ❌ No | Doesn't start with "admins_" |
-| `ops_*` | `ops_monitoring` | ✅ Yes | Starts with "ops_" |
-| `session1` | `session1` | ✅ Yes | Exact match |
-| `session1` | `session12` | ❌ No | Not exact match |
 
 ## Troubleshooting
 
 ### Command Rejected
-If you receive "❌ You are not authorized to execute this server command.":
-1. Check that your session ID is included in `CHATWOOT_PRIVILEGED_SESSIONS`
-2. Verify the session ID matches exactly (case-sensitive, no extra spaces)
-3. Restart the container after changing the environment variable
+If you receive "❌ Server commands are disabled for this ChatWoot integration.":
+1. Check the ChatWoot app configuration in the dashboard
+2. Verify if `disableServerCommands` is set to `true`
+3. Update the setting if you need server command access
 
 ### Logs
-Access denied attempts are logged as warnings:
+When server commands are blocked, you'll see:
 ```
-WARN: Access denied: session mysession attempted privileged command server reboot
+WARN: Server command server reboot is disabled for session mysession
 ```
 
 ## Migration
 
-This feature is backward compatible. Existing installations will continue to work without any changes. To enable restrictions, simply add the `CHATWOOT_PRIVILEGED_SESSIONS` environment variable with your desired session IDs.
+This feature is backward compatible:
+- **Existing Apps**: Continue working unchanged (`disableServerCommands: false` by default) and has validations on DTO and DIContainer.
+- **New Apps**: Can be configured with restrictions as needed
+- **No Breaking Changes**: All existing functionality remains intact
+
+## Security Best Practices
+
+1. **Principle of Least Privilege**: Only enable server commands for apps that truly need them
+2. **Separate Apps by Role**: Create different ChatWoot apps for different user types
+3. **Monitor Access**: Review logs for any blocked command attempts
+4. **Regular Audits**: Periodically review which apps have server command access
+5. **Environment Isolation**: Use stricter settings in production environments
+
+## Benefits of Per-App Configuration
+
+- **Granular Control**: Configure each ChatWoot integration independently
+- **Multi-tenant Safe**: Different customers can have different access levels
+- **Easy Management**: Control through the familiar dashboard interface
+- **Audit Trail**: Clear logging of configuration changes and access attempts
+- **No Environment Variables**: No need to manage complex environment variable lists

--- a/src/apps/chatwoot/consumers/inbox/commands.ts
+++ b/src/apps/chatwoot/consumers/inbox/commands.ts
@@ -36,6 +36,7 @@ export class ChatWootInboxCommandsConsumer extends ChatWootInboxMessageConsumer 
       job.data.session,
       container.Locale(),
       container.WAHASelf(),
+      container.isServerCommandsDisabled(),
     );
     return await handler.handle(body);
   }
@@ -99,6 +100,7 @@ class SessionCommandHandler {
     private session: string,
     private l: Locale,
     private waha: WAHASelf,
+    private serverCommandsDisabled: boolean,
   ) {}
 
   async handle(message: any) {
@@ -107,6 +109,15 @@ class SessionCommandHandler {
     this.logger.info(
       `Executing command ${command} for session ${this.session}`,
     );
+
+    // Check if server commands are disabled for this app
+    const serverCommands = [Command.SERVER_STATUS, Command.SERVER_REBOOT, Command.SERVER_REBOOT_FORCE];
+    if (this.serverCommandsDisabled && serverCommands.includes(command)) {
+      this.logger.warn(`Server command ${command} is disabled for session ${this.session}`);
+      const conversation = await this.repo.InboxNotifications();
+      await conversation.incoming('❌ Server commands are disabled for this ChatWoot integration.');
+      return;
+    }
 
     switch (command) {
       case Command.RESTART:

--- a/src/apps/chatwoot/consumers/inbox/commands.ts
+++ b/src/apps/chatwoot/consumers/inbox/commands.ts
@@ -107,6 +107,24 @@ class SessionCommandHandler {
     this.logger.info(
       `Executing command ${command} for session ${this.session}`,
     );
+
+    // Check privileged command access
+    const privilegedCommands = [Command.SERVER_REBOOT, Command.SERVER_REBOOT_FORCE, Command.SERVER_STATUS];
+    if (privilegedCommands.includes(command)) {
+      const privilegedSessionsEnv = process.env.CHATWOOT_PRIVILEGED_SESSIONS || '';
+      const privilegedSessions = privilegedSessionsEnv
+        ? privilegedSessionsEnv.split(',').map(s => s.trim()).filter(s => s.length > 0)
+        : [];
+
+      const hasAccess = privilegedSessions.length === 0 || this.isSessionAllowed(this.session, privilegedSessions);
+      if (!hasAccess) {
+        this.logger.warn(`Access denied: session ${this.session} attempted privileged command ${command}`);
+        const conversation = await this.repo.InboxNotifications();
+        await conversation.incoming('❌ You are not authorized to execute this server command.');
+        return;
+      }
+    }
+
     switch (command) {
       case Command.RESTART:
         await this.waha.restart(this.session);
@@ -194,6 +212,27 @@ class SessionCommandHandler {
       default:
         throw new CommandIsNotImplementedError(cmd);
     }
+  }
+
+  /**
+   * Check if a session is allowed based on exact match or wildcard patterns
+   */
+  private isSessionAllowed(sessionId: string, allowedPatterns: string[]): boolean {
+    for (const pattern of allowedPatterns) {
+      // Exact match
+      if (pattern === sessionId) {
+        return true;
+      }
+      
+      // Wildcard pattern matching (supports * at the end)
+      if (pattern.endsWith('*')) {
+        const prefix = pattern.slice(0, -1); // Remove the '*'
+        if (sessionId.startsWith(prefix)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   findCommand(text: string): Command {

--- a/src/apps/chatwoot/consumers/inbox/commands.ts
+++ b/src/apps/chatwoot/consumers/inbox/commands.ts
@@ -108,23 +108,6 @@ class SessionCommandHandler {
       `Executing command ${command} for session ${this.session}`,
     );
 
-    // Check privileged command access
-    const privilegedCommands = [Command.SERVER_REBOOT, Command.SERVER_REBOOT_FORCE, Command.SERVER_STATUS];
-    if (privilegedCommands.includes(command)) {
-      const privilegedSessionsEnv = process.env.CHATWOOT_PRIVILEGED_SESSIONS || '';
-      const privilegedSessions = privilegedSessionsEnv
-        ? privilegedSessionsEnv.split(',').map(s => s.trim()).filter(s => s.length > 0)
-        : [];
-
-      const hasAccess = privilegedSessions.length === 0 || this.isSessionAllowed(this.session, privilegedSessions);
-      if (!hasAccess) {
-        this.logger.warn(`Access denied: session ${this.session} attempted privileged command ${command}`);
-        const conversation = await this.repo.InboxNotifications();
-        await conversation.incoming('❌ You are not authorized to execute this server command.');
-        return;
-      }
-    }
-
     switch (command) {
       case Command.RESTART:
         await this.waha.restart(this.session);
@@ -212,27 +195,6 @@ class SessionCommandHandler {
       default:
         throw new CommandIsNotImplementedError(cmd);
     }
-  }
-
-  /**
-   * Check if a session is allowed based on exact match or wildcard patterns
-   */
-  private isSessionAllowed(sessionId: string, allowedPatterns: string[]): boolean {
-    for (const pattern of allowedPatterns) {
-      // Exact match
-      if (pattern === sessionId) {
-        return true;
-      }
-      
-      // Wildcard pattern matching (supports * at the end)
-      if (pattern.endsWith('*')) {
-        const prefix = pattern.slice(0, -1); // Remove the '*'
-        if (sessionId.startsWith(prefix)) {
-          return true;
-        }
-      }
-    }
-    return false;
   }
 
   findCommand(text: string): Command {

--- a/src/apps/chatwoot/di/DIContainer.ts
+++ b/src/apps/chatwoot/di/DIContainer.ts
@@ -198,4 +198,8 @@ export class DIContainer {
   public CustomAttributesAPI() {
     return new CustomAttributesAPI(this.config, this.AccountAPI());
   }
+
+  public isServerCommandsDisabled(): boolean {
+    return this.config.disableServerCommands || false;
+  }
 }

--- a/src/apps/chatwoot/dto/config.dto.ts
+++ b/src/apps/chatwoot/dto/config.dto.ts
@@ -1,6 +1,6 @@
 import { ChatWootAPIConfig } from '@waha/apps/chatwoot/client/interfaces';
 import { DEFAULT_LOCALE, LOCALES } from '@waha/apps/chatwoot/locale';
-import { IsIn, IsNumber, IsString } from 'class-validator';
+import { IsBoolean, IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class ChatWootAppConfig implements ChatWootAPIConfig {
   @IsString()
@@ -21,4 +21,8 @@ export class ChatWootAppConfig implements ChatWootAPIConfig {
   @IsString()
   @IsIn(LOCALES)
   locale: string = DEFAULT_LOCALE;
+
+  @IsBoolean()
+  @IsOptional()
+  disableServerCommands: boolean = false;
 }


### PR DESCRIPTION
## Overview

By default, any session connected to ChatWoot can execute server commands like:
- `server status` - Get server version and status information
- `server reboot` - Gracefully reboot the server
- `server reboot force` - Force reboot the server

For security reasons, you may want to restrict these commands to only specific trusted sessions. This is especially the case when using the same instance for several customers and want to restrict sensitive commands to certain privileged sessions, or to avoid accidental server reboots that can disrupt the service level.

- Introduced CHATWOOT_PRIVILEGED_SESSIONS environment variable to restrict access to sensitive server commands.
- Implemented checks in the command handler to validate session access based on configured privileges.
- Added documentation for ChatWoot integration security and configuration examples. @devlikepro this is entirely optional and you can opt-out this file completely if you want, just added it to properly document my changes and the way I intend them to work.

I'm not entirely proficient in NestJS, thus I'm not sure if this is "the right way" to implement this feature. If so, I hope it serves as inspiration to implement it.

[![patron:PLUS](https://img.shields.io/badge/patron-PLUS-a0e6ba)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)