### PR TITLE
Add GitHub Actions workflow for multi-architecture Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,8 +15,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  DOCKER_IMAGE_CORE: ghcr.io/${{ github.repository_owner }}/waha
-  DOCKER_IMAGE_PLUS: ghcr.io/${{ github.repository_owner }}/waha-plus
 
 jobs:
   build:
@@ -29,9 +27,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - name: ${{ env.DOCKER_IMAGE_CORE }}
+          - name: ghcr.io/${{ github.repository_owner }}/waha
             dockerfile: Dockerfile
-          - name: ${{ env.DOCKER_IMAGE_PLUS }}
+          - name: ghcr.io/${{ github.repository_owner }}/waha-plus
             dockerfile: Dockerfile
             # Uncomment if Plus has a separate Dockerfile
             # dockerfile: Dockerfile.plus

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,83 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  DOCKER_IMAGE_CORE: ghcr.io/${{ github.repository_owner }}/waha
+  DOCKER_IMAGE_PLUS: ghcr.io/${{ github.repository_owner }}/waha-plus
+
+jobs:
+  build:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        image:
+          - name: ${{ env.DOCKER_IMAGE_CORE }}
+            dockerfile: Dockerfile
+          - name: ${{ env.DOCKER_IMAGE_PLUS }}
+            dockerfile: Dockerfile
+            # Uncomment if Plus has a separate Dockerfile
+            # dockerfile: Dockerfile.plus
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NODE_IMAGE_TAG=22.16-bookworm-slim
+            GOLANG_IMAGE_TAG=1.23-bookworm
+


### PR DESCRIPTION
# Add GitHub Actions workflow for multi-architecture Docker builds

## Summary

This PR adds a GitHub Actions workflow to automatically build and publish Docker images for both AMD64 and ARM64 architectures to GitHub Container Registry (ghcr.io).

## Changes

- **New GitHub Actions workflow** (`.github/workflows/docker-build.yml`)
  - Builds Docker images for both `linux/amd64` and `linux/arm64` platforms
  - Publishes images to GitHub Container Registry (`ghcr.io`)
  - Supports both Core (`waha`) and Plus (`waha-plus`) image variants
  - Uses Docker Buildx for multi-architecture builds
  - Implements GitHub Actions cache for faster builds

## Features

### Multi-Architecture Support
- Builds images for both AMD64 and ARM64 architectures simultaneously
- Uses Docker Buildx with QEMU emulation for cross-platform builds

### Image Publishing
- Publishes to GitHub Container Registry: `ghcr.io/{owner}/waha` and `ghcr.io/{owner}/waha-plus`
- Automatic tagging based on:
  - Branch names (for branch pushes)
  - Semantic versioning (for tags like `v1.0.0`)
  - `latest` tag for default branch
  - PR numbers (for pull requests)

### Workflow Triggers
- Push to `main` or `master` branches
- Push of version tags (e.g., `v1.0.0`)
- Pull requests (builds only, no push)
- Manual workflow dispatch

### Build Optimization
- Uses GitHub Actions cache (`type=gha`) to speed up subsequent builds
- Builds both Core and Plus variants in parallel using matrix strategy

## Usage

After merging, Docker images will be automatically built and published to GitHub Packages on:
- Every push to the main branch
- Every version tag release
- Pull requests (for testing)

To pull the images:
```bash
docker pull ghcr.io/{owner}/waha:latest
docker pull ghcr.io/{owner}/waha-plus:latest
```

## Technical Details

- Uses `GITHUB_TOKEN` for authentication (no additional secrets required)
- Requires `packages: write` permission (already configured)
- Builds use the same Dockerfile for both Core and Plus variants
- Build arguments are set for Node.js and Go versions

## Notes

- The workflow skips pushing images on pull requests (only builds for testing)
- Images are publicly visible in the repository's Packages section
- For private repositories, users may need to authenticate with GitHub token to pull images

