### PR TITLE
Fixes #1763

### DIFF
--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -247,9 +247,9 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
     args.unshift(`--a-waha-timestamp=${new Date()}`);
     args.unshift(`--a-waha-session=${this.name}`);
     const deviceName =
-      this.sessionConfig.client?.deviceName ?? WAHA_CLIENT_DEVICE_NAME;
+      this.sessionConfig?.client?.deviceName ?? WAHA_CLIENT_DEVICE_NAME;
     const browserName =
-      this.sessionConfig.client?.browserName ?? WAHA_CLIENT_BROWSER_NAME;
+      this.sessionConfig?.client?.browserName ?? WAHA_CLIENT_BROWSER_NAME;
     return {
       puppeteer: {
         protocolTimeout: 300_000,


### PR DESCRIPTION
Fixes #1763

`sessionConfig` is `null` during WEBJS autostart (`WHATSAPP_RESTART_ALL_SESSIONS`/`WHATSAPP_START_SESSION`) because config comes from `.env` vars, not session storage yet.

**Fix**: Added null-check `this.sessionConfig?.client?.deviceName` following the same defensive pattern used in `getWebjsTagsFlag()`.

Now works for:
- Autostart (uses `WAHA_CLIENT_*` env vars)
- Dashboard/manual start (uses session config)
