### PR TITLE
Sidestep existing .env from being overwritten

### DIFF
--- a/src/core/auth/config.ts
+++ b/src/core/auth/config.ts
@@ -142,7 +142,7 @@ export function ReportGeneratedValue() {
     'Save these values to your environment (.env or WAHA_*) to reuse them; new keys are generated on every start otherwise.',
   );
   console.warn('');
-  console.warn("cat <<'EOF' > .env");
+  console.warn("cat <<'EOF' >> .env");
   console.warn('');
   for (const key of values) {
     console.warn(`${key.param}=${key.value}`);


### PR DESCRIPTION
Following docker log instructions currently wipes .env if it's already configured