### PR TITLE
fix: include assignedWorker in session create/get response

### DIFF
--- a/src/core/manager.core.ts
+++ b/src/core/manager.core.ts
@@ -361,6 +361,7 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
           status: WAHASessionStatus.STOPPED,
           config: this.sessionConfig,
           me: null,
+          assignedWorker: this.workerId,
           presence: null,
           timestamps: {
             activity: null,
@@ -383,6 +384,7 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
         status: session.status,
         config: session.sessionConfig,
         me: me,
+        assignedWorker: this.workerId,
         presence: session.presence,
         timestamps: {
           activity: session?.getLastActivityTimestamp(),


### PR DESCRIPTION
**Issue:** `POST /api/sessions` (and `GET /api/sessions/{name}`) don't return `assignedWorker`, even though `SessionInfo` DTO already declares it and `GET /api/sessions` (list) does return it.
**Root cause:** `getSessions()` in `manager.core.ts` never sets `assignedWorker`. The plus edition's `listSessions()` adds it after the fact from the worker repository, but `getSessionInfo()` doesn't.

**Fix — two files:**
1. **`src/core/manager.core.ts`** — add `assignedWorker: this.workerId` to both return paths in `getSessions()` (STOPPED path and active path). *(Already patched in this PR.)*
2. **`src/plus/manager.plus.ts`** — in `getSessionInfo()`, add `assignedWorker: this.workerId` to the return object. It currently returns `{ ...session, engine }` — change it to `{ ...session, engine, assignedWorker: this.workerId }`.