### PR TITLE
[core] fix: harden auth middleware, WebSocket guard, and policies guard

### DIFF
--- a/src/api/websocket.gateway.core.ts
+++ b/src/api/websocket.gateway.core.ts
@@ -93,6 +93,7 @@ export class WebsocketGatewayCore
 
     if (!ability.can(Action.Use, new SessionName(session))) {
       socket.close(WebSocketCloseCode.POLICY_VIOLATION, 'Forbidden');
+      return;
     }
 
     this.logger.debug(`New client connected: ${request.url} - ${socket.id}`);

--- a/src/core/auth/api-key-auth.middleware.ts
+++ b/src/core/auth/api-key-auth.middleware.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  InternalServerErrorException,
   NestMiddleware,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -16,7 +15,7 @@ export class ApiKeyAuthMiddleware implements NestMiddleware {
         const exception =
           err instanceof UnauthorizedException
             ? err
-            : new InternalServerErrorException();
+            : new UnauthorizedException();
         res.status(exception.getStatus()).json(exception.getResponse());
         return;
       }

--- a/src/core/auth/policies.guard.ts
+++ b/src/core/auth/policies.guard.ts
@@ -26,6 +26,10 @@ export class PoliciesGuard implements CanActivate {
         context.getClass(),
       ]) || [];
 
+    if (handlers.length === 0) {
+      throw new ForbiddenException();
+    }
+
     const req = context.switchToHttp().getRequest();
     const user = req.user;
     const ability = this.caslAbilityFactory.createForUser(user);


### PR DESCRIPTION
## Summary

Three minimal security hardening fixes for the authentication/authorization layer:

- **WebSocket gateway** (`src/api/websocket.gateway.core.ts`): Add missing `return` after `socket.close()` when a session-scoped key fails the CASL ability check. Without the return, execution falls through and subscribes to the forbidden session's event stream, creating a race condition where events can leak before the TCP close completes.

- **API key middleware** (`src/core/auth/api-key-auth.middleware.ts`): Return `401 Unauthorized` instead of `500 Internal Server Error` when the `X-Api-Key` header is missing or malformed. The `passport-headerapikey` library throws a `BadRequestError` (not `UnauthorizedException`) for missing headers, which was incorrectly wrapped as a 500.

- **PoliciesGuard** (`src/core/auth/policies.guard.ts`): Deny by default when no `@CheckPolicies` handlers are defined on an endpoint. Previously, an empty handlers array caused `[].every()` to return `true`, auto-passing authorization. This prevents accidental exposure if a new endpoint is added with `@UseGuards(PoliciesGuard)` but without `@CheckPolicies`.

## Changes

| File | Change |
|------|--------|
| `src/api/websocket.gateway.core.ts` | +1 line: `return` after `socket.close()` |
| `src/core/auth/api-key-auth.middleware.ts` | `InternalServerErrorException` → `UnauthorizedException` |
| `src/core/auth/policies.guard.ts` | +4 lines: deny when `handlers.length === 0` |

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (76 tests, 0 failures)
- [ ] Verify WebSocket correctly disconnects forbidden sessions without leaking events
- [ ] Verify missing `X-Api-Key` header returns HTTP 401 instead of 500
- [ ] Verify endpoints with `@UseGuards(PoliciesGuard)` but no `@CheckPolicies` return 403