### PR TITLE
[core] fix: strip escaped newlines from ChatWoot v4.10.1+ messages

### DIFF
--- a/src/apps/chatwoot/messages/to/whatsapp/markdown.test.ts
+++ b/src/apps/chatwoot/messages/to/whatsapp/markdown.test.ts
@@ -15,6 +15,12 @@ describe('MarkdownToWhatsApp', () => {
     expect(MarkdownToWhatsApp(input)).toBe(expected);
   });
 
+  // ChatWoot v4.10.1+ escapes newlines with trailing backslash
+  it('strips trailing backslash before newlines', () => {
+    const input = 'Hi \\\ntext message \\\nwith line \\\nbreak';
+    expect(MarkdownToWhatsApp(input)).toBe('Hi \ntext message \nwith line \nbreak');
+  });
+
   // Tests for URL protection
   it('preserves URLs with multiple underscores', () => {
     const input = 'https://example.com/page__name__test';

--- a/src/apps/chatwoot/messages/to/whatsapp/markdown.ts
+++ b/src/apps/chatwoot/messages/to/whatsapp/markdown.ts
@@ -4,6 +4,8 @@ export function MarkdownToWhatsApp(text: string): string {
   }
   return (
     text
+      // Remove trailing backslash before newlines (ChatWoot v4.10.1+ escaping)
+      .replace(/\\\n/g, '\n')
       // Triple-backtick blocks → WhatsApp monospace blocks (same syntax)
       .replace(/```([\s\S]*?)```/g, '```$1```')
       // Italic **first**, but only single‐star or single‐underscore


### PR DESCRIPTION
## Summary

Fixes line breaks appearing as literal backslashes in WhatsApp messages when using ChatWoot v4.10.1+.

ChatWoot v4.10.1 changed how newlines are encoded in webhook payloads: each line break is now preceded by a trailing backslash (`\`). WAHA passed this through to WhatsApp as-is, causing messages like:

```
Hi \
text message \
with line \
break
```

instead of:

```
Hi
text message
with line
break
```

## Changes

| File | Change |
|------|--------|
| `src/apps/chatwoot/messages/to/whatsapp/markdown.ts` | Strip trailing `\` before newlines in `MarkdownToWhatsApp()` |
| `src/apps/chatwoot/messages/to/whatsapp/markdown.test.ts` | Add test case for escaped newlines |

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (77 tests, 0 failures)
- [x] New test verifies `"Hi \\\ntext"` becomes `"Hi \ntext"`
- [ ] Verify with ChatWoot v4.10.1+ that line breaks render correctly in WhatsApp

Closes #1833