### PR TITLE
Fix GOWS chats/overview missing contact name and WEBJS presence with @lid

### DIFF
--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -1866,14 +1866,30 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
 
   protected async fetchChatSummary(chat): Promise<ChatSummary> {
     const id = toCusFormat(chat.id);
-    const name = chat.name;
+    let name = chat.name;
+    if (!name) {
+      try {
+        const jid = toJID(chat.id);
+        const request = new messages.EntityByIdRequest({
+          session: this.session,
+          id: jid,
+        });
+        const response = await promisify(this.client.GetContactById)(request);
+        const contactData = parseJson(response);
+        if (contactData) {
+          name = contactData.Name || contactData.PushName;
+        }
+      } catch (e) {
+        // Ignore contact lookup errors
+      }
+    }
     const picture = await this.getContactProfilePicture(chat.id, false);
-    const messages = await this.getChatMessages(
+    const chatMessages = await this.getChatMessages(
       chat.id,
       { limit: 1, offset: 0, downloadMedia: false },
       {},
     );
-    const message = messages.length > 0 ? messages[0] : null;
+    const message = chatMessages.length > 0 ? chatMessages[0] : null;
     return {
       id: id,
       name: name || null,

--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -175,6 +175,7 @@ import { WAJSPresenceChatStateType, WebJSPresence } from './types';
 import {
   isJidGroup,
   isJidStatusBroadcast,
+  isLidUser,
   normalizeJid,
   toCusFormat,
 } from '@waha/core/utils/jids';
@@ -1543,14 +1544,26 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
 
   @Activity()
   public async getPresence(id: string): Promise<WAHAChatPresences> {
-    const chatId = toCusFormat(id);
+    let chatId = toCusFormat(id);
+    if (isLidUser(chatId)) {
+      const pn = await this.whatsapp.findPNByLid(chatId);
+      if (pn) {
+        chatId = toCusFormat(pn);
+      }
+    }
     const presences = await this.whatsapp.getPresence(chatId);
     return this.toWahaPresences(chatId, presences);
   }
 
   @Activity()
   public async subscribePresence(id: string): Promise<any> {
-    const chatId = toCusFormat(id);
+    let chatId = toCusFormat(id);
+    if (isLidUser(chatId)) {
+      const pn = await this.whatsapp.findPNByLid(chatId);
+      if (pn) {
+        chatId = toCusFormat(pn);
+      }
+    }
     await this.whatsapp.subscribePresence(chatId);
   }
 


### PR DESCRIPTION
## Summary

- **GOWS engine**: Fix missing contact name in `/api/{session}/chats/overview` endpoint. When `chat.name` is null (common with GOWS gRPC responses), the code now falls back to looking up the contact via `GetContactById` and uses `Name` or `PushName`. Follows the same pattern as the NOWEB engine.
- **WEBJS engine**: Fix presence API not working with `@lid` chat IDs. `getPresence()` and `subscribePresence()` now convert `@lid` to `@c.us` format using `findPNByLid()` before passing to the underlying client, since `getCurrentPresence()` only handles `@c.us` format correctly.

Fixes #1910
Fixes #1845

## Test plan

- [ ] GOWS: Call `GET /api/{session}/chats/overview` and verify contact names are populated (not null)
- [ ] WEBJS: Call `GET /api/{session}/presence/{lid_chat_id}` with an `@lid` format ID and verify presence data is returned
- [ ] WEBJS: Call `GET /api/{session}/presence/{c_us_chat_id}` with an `@c.us` format ID and verify it still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)