### PR TITLE
fix(webjs): handle null chat in typing and seen endpoints

### DIFF
--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -1,4 +1,7 @@
-import { UnprocessableEntityException } from '@nestjs/common';
+import {
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import {
   getChannelInviteLink,
   WhatsappSession,
@@ -882,25 +885,37 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
 
   @Activity()
   async sendSeen(request: SendSeenRequest) {
-    const chat: Chat = await this.whatsapp.getChatById(
-      this.ensureSuffix(request.chatId),
-    );
+    const chatId = this.ensureSuffix(request.chatId);
+    const chat: Chat = await this.whatsapp.getChatById(chatId);
+    if (!chat) {
+      throw new NotFoundException(
+        `Chat '${request.chatId}' not found. The number may not have WhatsApp.`,
+      );
+    }
     await chat.sendSeen();
   }
 
   @Activity()
   async startTyping(request: ChatRequest): Promise<void> {
-    const chat: Chat = await this.whatsapp.getChatById(
-      this.ensureSuffix(request.chatId),
-    );
+    const chatId = this.ensureSuffix(request.chatId);
+    const chat: Chat = await this.whatsapp.getChatById(chatId);
+    if (!chat) {
+      throw new NotFoundException(
+        `Chat '${request.chatId}' not found. The number may not have WhatsApp.`,
+      );
+    }
     await chat.sendStateTyping();
   }
 
   @Activity()
   async stopTyping(request: ChatRequest) {
-    const chat: Chat = await this.whatsapp.getChatById(
-      this.ensureSuffix(request.chatId),
-    );
+    const chatId = this.ensureSuffix(request.chatId);
+    const chat: Chat = await this.whatsapp.getChatById(chatId);
+    if (!chat) {
+      throw new NotFoundException(
+        `Chat '${request.chatId}' not found. The number may not have WhatsApp.`,
+      );
+    }
     await chat.clearState();
   }
 


### PR DESCRIPTION
## Bug
[#1970](https://github.com/devlikeapro/waha/issues/1970) — `POST /api/startTyping` returns a 500 Internal Server Error with `TypeError: Cannot read properties of undefined (reading 'sendStateTyping')` when the target number does not have WhatsApp.

## Fix
Added null checks after `getChatById()` in the WEBJS engine's `startTyping`, `stopTyping`, and `sendSeen` methods. When the chat object is not found (e.g. the number has no WhatsApp account), these endpoints now throw a `NotFoundException` with a descriptive message instead of crashing with an unhandled `TypeError`.

The same pattern is already used elsewhere in the codebase (e.g. session manager's `NotFoundException`).

## Testing
Verified that the fix correctly guards all three affected methods. NestJS maps `NotFoundException` to a 404 HTTP response, giving callers a clear signal that the chat does not exist rather than an opaque 500 error.

Happy to address any feedback.

Greetings, saschabuehrle