### PR TITLE
[core] fix /jobs access by excluding it from global Swagger basic auth

### DIFF
--- a/src/core/SwaggerConfiguratorCore.ts
+++ b/src/core/SwaggerConfiguratorCore.ts
@@ -195,6 +195,8 @@ export class SwaggerConfiguratorCore {
       '/ping',
       '/ws',
       '/webhooks/',
+      '/jobs',
+      '/jobs/',
       ...config.getExcludedFullPaths(),
     ]);
 


### PR DESCRIPTION
## Summary

`/jobs` is already protected by its own auth middleware in the apps module, but it is not excluded from the global basic auth configured in `SwaggerConfiguratorCore`.

As a result, the Jobs UI can end up behind two auth layers and return repeated 401 responses even when credentials are configured correctly.

## Change

Add `/jobs` and `/jobs/` to the global auth exclude list in `src/core/SwaggerConfiguratorCore.ts`.

## Why

This keeps `/jobs` protected by its dedicated auth middleware while avoiding the double-auth behavior from the global Swagger basic auth layer.

## Validation

Confirmed in a live deployment running WAHA `2026.3.2`: after excluding `/jobs` and `/jobs/` from the global Swagger basic auth layer, the Jobs UI became accessible again. I did not add a new automated test for this change, since the fix is limited to the auth exclude list and was verified in a live deployment.

## Related issues

- #1679
- #1398

[![patron:PLUS](https://img.shields.io/badge/patron-PLUS-a0e6ba)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)