### PR TITLE
fix(noweb): use stream mode for media download to fix 0-byte audio files

### DIFF
--- a/src/core/engines/noweb/session.noweb.core.ts
+++ b/src/core/engines/noweb/session.noweb.core.ts
@@ -2848,9 +2848,12 @@ export class NOWEBEngineMediaProcessor implements IMediaEngineProcessor<any> {
       content.url = null;
     }
 
-    return (await downloadMediaMessage(
+    // Use 'stream' mode instead of 'buffer' to fix 0-byte audio files
+    // 'buffer' mode silently returns empty buffer for audio/voice messages
+    // See: https://github.com/devlikeapro/waha/issues/1996
+    const stream = await downloadMediaMessage(
       message,
-      'buffer',
+      'stream',
       {},
       {
         logger: this.logger,
@@ -2859,7 +2862,12 @@ export class NOWEBEngineMediaProcessor implements IMediaEngineProcessor<any> {
     ).finally(() => {
       // Set url back in case we removed it
       content.url = url;
-    })) as Buffer;
+    });
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
   }
 
   getFilename(message: any): string | null {


### PR DESCRIPTION
## Summary

Fixes #1996 — voice/audio messages (PTT, OGG Opus) are saved as 0-byte empty files when using NOWEB engine with S3 media storage, while images download correctly.

### Root cause

`downloadMediaMessage()` in Baileys silently returns an empty buffer for audio messages when called with `'buffer'` mode. No error is thrown — the file is simply empty.

Related Baileys issues:
- https://github.com/WhiskeySockets/Baileys/issues/681
- https://github.com/openclaw/openclaw/issues/4636

### Fix

Switch from `'buffer'` to `'stream'` mode and collect chunks manually. One-method change in `getMediaBuffer()`.

### Tested in production

WAHA Plus 2026.3.4, NOWEB engine, S3 storage (AWS eu-central-1):

| | Before | After |
|---|---|---|
| Voice message (OGG) | 0 bytes | 58,005 bytes ✅ |
| Image (JPEG) | Works | Works ✅ |

The patched compiled JS has been running in production since 2026-04-02 with no issues.