### PR TITLE
fix: prevent setTimeout overflow for large WHATSAPP_FILES_LIFETIME values

### DIFF
--- a/src/core/media/local/MediaLocalStorage.ts
+++ b/src/core/media/local/MediaLocalStorage.ts
@@ -14,6 +14,7 @@ const writeFileAtomic = require('write-file-atomic');
  * Save files locally using the filesystem
  */
 export class MediaLocalStorage implements IMediaStorage {
+  private static readonly MAX_SETTIMEOUT_MS = 2_147_483_647;
   private readonly lifetimeMs: number;
 
   constructor(
@@ -25,6 +26,12 @@ export class MediaLocalStorage implements IMediaStorage {
     this.lifetimeMs = lifetimeSeconds * SECOND;
     if (this.lifetimeMs === 0) {
       this.log.info('Files lifetime is 0, files will not be removed');
+    }
+    if (this.lifetimeMs > MediaLocalStorage.MAX_SETTIMEOUT_MS) {
+      this.log.warn(
+        `Files lifetime ${lifetimeSeconds}s (${this.lifetimeMs}ms) exceeds setTimeout ` +
+          `max (${MediaLocalStorage.MAX_SETTIMEOUT_MS}ms). Using setInterval-based cleanup instead.`,
+      );
     }
   }
 
@@ -84,13 +91,26 @@ export class MediaLocalStorage implements IMediaStorage {
     if (this.lifetimeMs === 0) {
       return;
     }
-    setTimeout(
-      () =>
-        fs.unlink(filepath, () => {
-          this.log.info(`File ${filepath} was removed`);
-        }),
-      this.lifetimeMs,
-    );
+    const remove = () =>
+      fs.unlink(filepath, () => {
+        this.log.info(`File ${filepath} was removed`);
+      });
+    if (this.lifetimeMs <= MediaLocalStorage.MAX_SETTIMEOUT_MS) {
+      setTimeout(remove, this.lifetimeMs);
+    } else {
+      // For lifetimes exceeding setTimeout's 32-bit signed int max,
+      // chain multiple timeouts to avoid silent overflow to ~1ms.
+      let remaining = this.lifetimeMs;
+      const step = () => {
+        if (remaining <= MediaLocalStorage.MAX_SETTIMEOUT_MS) {
+          setTimeout(remove, remaining);
+        } else {
+          remaining -= MediaLocalStorage.MAX_SETTIMEOUT_MS;
+          setTimeout(step, MediaLocalStorage.MAX_SETTIMEOUT_MS);
+        }
+      };
+      step();
+    }
   }
 
   async close() {


### PR DESCRIPTION
## Summary

Fixes #2018 — `WHATSAPP_FILES_LIFETIME` values exceeding ~24.8 days cause a silent `setTimeout` overflow, deleting media files immediately after creation.

## Problem

JavaScript's `setTimeout` uses a 32-bit signed integer for the delay parameter (max `2,147,483,647` ms). When `WHATSAPP_FILES_LIFETIME` is set to `2592000` (30 days), the calculation `2592000 * 1000 = 2,592,000,000 ms` exceeds this limit. Node.js silently overflows to ~1ms, causing `postponeRemoval()` to delete every saved media file within milliseconds of creation.

**Impact:** All incoming media files appear to download successfully ("The media has been saved") but are immediately deleted. The `/api/files/` endpoint returns 404 for every media URL. Users see broken images/documents in their chat.

The only visible symptom is a Node.js `TimeoutOverflowWarning` in stderr that's easy to miss:
```
(node:1) TimeoutOverflowWarning: 2592000000 does not fit into a 32-bit signed integer.
```

## Fix

- When `lifetimeMs` is within the 32-bit limit: use `setTimeout` directly (no behavior change)
- When `lifetimeMs` exceeds the limit: chain multiple `setTimeout` calls, each at most `MAX_SETTIMEOUT_MS`, to support arbitrarily large lifetimes
- Log a warning at startup when the overflow threshold is exceeded

## Safe values reference

| WHATSAPP_FILES_LIFETIME | lifetimeMs | Status |
|---|---|---|
| `86400` (1 day) | 86,400,000 | ✅ Safe |
| `604800` (7 days) | 604,800,000 | ✅ Safe |
| `2147483` (~24.8 days) | 2,147,483,000 | ✅ Safe (max for single setTimeout) |
| `2592000` (30 days) | 2,592,000,000 | ❌ **Overflow → instant deletion** (now fixed) |
| `0` (disabled) | 0 | ✅ Safe (no deletion) |

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)