### PR TITLE
feat: add forMe query param to DELETE /messages for local-only deletion

### DIFF
--- a/src/api/chats.controller.ts
+++ b/src/api/chats.controller.ts
@@ -26,6 +26,7 @@ import {
   ChatPictureQuery,
   ChatPictureResponse,
   ChatSummary,
+  DeleteMessageQuery,
   GetChatMessageQuery,
   GetChatMessagesFilter,
   GetChatMessagesQuery,
@@ -216,8 +217,9 @@ class ChatsController {
     @WorkingSessionParam session: WhatsappSession,
     @Param('chatId') chatId: string,
     @Param('messageId') messageId: string,
+    @Query() query: DeleteMessageQuery,
   ) {
-    return session.deleteMessage(chatId, messageId);
+    return session.deleteMessage(chatId, messageId, query.forMe);
   }
 
   @Put(':chatId/messages/:messageId')

--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -740,7 +740,7 @@ export abstract class WhatsappSession {
     throw new NotImplementedByEngineError();
   }
 
-  public deleteMessage(chatId: string, messageId: string) {
+  public deleteMessage(chatId: string, messageId: string, forMe?: boolean) {
     throw new NotImplementedByEngineError();
   }
 

--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -1013,7 +1013,7 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   @Activity()
-  public async deleteMessage(chatId: string, messageId: string) {
+  public async deleteMessage(chatId: string, messageId: string, forMe?: boolean) {
     const jid = normalizeJid(toJID(this.ensureSuffix(chatId)));
     const key = parseMessageIdSerialized(messageId);
     const message = new messages.RevokeMessageRequest({

--- a/src/core/engines/noweb/session.noweb.core.ts
+++ b/src/core/engines/noweb/session.noweb.core.ts
@@ -948,7 +948,7 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   @Activity()
-  public deleteMessage(chatId: string, messageId: string) {
+  public deleteMessage(chatId: string, messageId: string, forMe?: boolean) {
     const jid = toJID(this.ensureSuffix(chatId));
     const key = parseMessageIdSerialized(messageId);
     const options = {

--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -774,9 +774,9 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
   }
 
   @Activity()
-  public deleteMessage(chatId: string, messageId: string) {
+  public deleteMessage(chatId: string, messageId: string, forMe?: boolean) {
     const message = this.recreateMessage(messageId);
-    return message.delete(true);
+    return message.delete(!forMe);
   }
 
   @Activity()

--- a/src/structures/chats.dto.ts
+++ b/src/structures/chats.dto.ts
@@ -220,6 +220,20 @@ export enum PinDuration {
   MONTH = 2592000,
 }
 
+export class DeleteMessageQuery {
+  @ApiProperty({
+    example: false,
+    required: false,
+    description:
+      'Delete message for the current user only (local deletion). ' +
+      'If false, attempts to revoke the message for everyone.',
+  })
+  @Transform(BooleanString)
+  @IsBoolean()
+  @IsOptional()
+  forMe?: boolean = false;
+}
+
 export class PinMessageRequest {
   @IsNumber()
   @IsEnum(PinDuration)


### PR DESCRIPTION

Closes #2022 

### Summary

Adds a `forMe` boolean query parameter to `DELETE /api/{session}/chats/{chatId}/messages/{messageId}`.

When `forMe=true`, the WEBJS engine calls `message.delete(false)` instead of `message.delete(true)`, triggering a local-only deletion (`sendDeleteMsgs`) instead of a revoke (`sendRevokeMsgs`). This enables true "delete for me" behavior for sent messages.

### Changes

- `src/structures/chats.dto.ts` — New `DeleteMessageQuery` class
- `src/api/chats.controller.ts` — Accept `@Query()` and pass `forMe` to session
- `src/core/abc/session.abc.ts` — Updated abstract signature
- `src/core/engines/webjs/session.webjs.core.ts` — `message.delete(!forMe)` (the actual fix)
- `src/core/engines/noweb/session.noweb.core.ts` — Signature update
- `src/core/engines/gows/session.gows.core.ts` — Signature update

### Backward Compatible

- Default value: `forMe = false`
- Without the parameter, behavior is identical to current code
- No breaking changes to existing API consumers

### Tested

- WEBJS engine, Docker on macOS ARM64
- Confirmed local-only deletion for both sent and received messages with `forMe=true`
- Confirmed existing revoke behavior preserved without the parameter
